### PR TITLE
fix the key name of the array of abilities-v1 json objects

### DIFF
--- a/file-transfer-protocol.md
+++ b/file-transfer-protocol.md
@@ -78,7 +78,7 @@ The `transit` message mentioned above is encoded following this schema:
     "transit": {
         "abilities-v1": [
             {
-                "kind": "<string, one of {direct-tcp-v1, relay-v1, tor-tcp-v1}>"
+                "type": "<string, one of {direct-tcp-v1, relay-v1, tor-tcp-v1}>"
             }
         ],
         "hints-v1": [


### PR DESCRIPTION
Transit message should look like this..

```
"transit": {
        "abilities-v1": [
            {
                "type": "<string, one of {direct-tcp-v1, relay-v1, tor-tcp-v1}>"
            }
        ],
        ....
```
The key in the arrays is `type` not `kind`.