### PR TITLE
Improve "welcome" message

### DIFF
--- a/server-protocol.md
+++ b/server-protocol.md
@@ -84,6 +84,22 @@ and handle them accordingly, if present:
   to the user. The value *should* be a plain string.
 * `error`: The client should show this message to the user and then terminate.
   The value *should* be a plain string.
+* `relays`: An advertizement list of relay servers. It is a JSON list of which each
+  entry may look like this:
+    ```json
+    {
+      "url": "tcp:myrelay.example.org:12345",
+      "country": "IT",
+      "continent": "EU",
+    }
+    ```
+  The only mandatory key is `url`, all others are optional information to help the client
+  choose an appropriate one. Further keys may be added in the future. Clients must not
+  expect the protocol to be `tcp` (expect websockets support in the future). Clients
+  should make a preselection of viable relay servers (which may include entries from other
+  sources as well), and randomly select one or two (together with the other side's, this
+  makes up to four, which should be enough to have a high probability of at least one being
+  reachable).
 * `permission-required`: a set of available authentication methods,
   proof of work challenges etc. The client needs to "solve" one of
   them in order to get access to the service.

--- a/server-protocol.md
+++ b/server-protocol.md
@@ -88,15 +88,21 @@ and handle them accordingly, if present:
   entry may look like this:
     ```json
     {
-      "url": "tcp:myrelay.example.org:12345",
+      "url": "tcp://myrelay.example.org:12345/",
       "country": "IT",
       "continent": "EU",
     }
     ```
-  The only mandatory key is `url`, all others are optional information to help the client
-  choose an appropriate one. Further keys may be added in the future. Clients must not
-  expect the protocol to be `tcp` (expect websockets support in the future). Clients
-  should make a preselection of viable relay servers (which may include entries from other
+  * The only mandatory key is `url`, all others are optional information to help the client
+    choose an appropriate one.
+      * Clients must not expect the protocol to be `tcp` (expect websockets support in the future).
+      * A `tcp`-schemed URL only has the `scheme` and `authority` part (`path` is empty, no `query`
+      and `fragment`), and the `authority` part only has `host` and `port` (no `userinfo`). There is
+      no default port number. Thus, it looks like `tcp://host:port/`, nothing more.
+  * `country` and `continent` are two-letter capitalized country/continent codes following ISO 3166.
+  * Further keys may be added in the future.
+
+  Clients should make a preselection of viable relay servers (which may include entries from other
   sources as well), and randomly select one or two (together with the other side's, this
   makes up to four, which should be enough to have a high probability of at least one being
   reachable).

--- a/server-protocol.md
+++ b/server-protocol.md
@@ -72,19 +72,18 @@ messages. Clients must ignore unrecognized message types from the Server.
 
 The first thing the server sends to each client is the `welcome` message.
 This is intended to deliver important status information to the client that
-might influence its operation. The Python client currently reacts to the
-following keys (and ignores all others):
+might influence its operation. Clients should look out for the following fields,
+and handle them accordingly, if present:
 
-* `current_cli_version`: prompts the user to upgrade if the server's
+* `current_cli_version`: *(deprecated)* prompts the user to upgrade if the server's
   advertised version is greater than the client's version (as derived from
   the git tag)
-* `motd`: prints this message, if present; intended to inform users about
+* `motd`: This message is intended to inform users about
   performance problems, scheduled downtime, or to beg for donations to keep
-  the server running
-* `error`: causes the client to print the message and then terminate. If a
-  future version of the protocol requires a rate-limiting CAPTCHA ticket or
-  other authorization record, the server can send `error` (explaining the
-  requirement) if it does not see this ticket arrive before the `bind`.
+  the server running. Clients should print it or otherwise display prominently
+  to the user. The value *should* be a plain string.
+* `error`: The client should show this message to the user and then terminate.
+  The value *should* be a plain string.
 * `permission-required`: a set of available authentication methods,
   proof of work challenges etc. The client needs to "solve" one of
   them in order to get access to the service.


### PR DESCRIPTION
1. It promotes a list of known relay servers to use
2. It gives a proof of work challenge to solve

The list of known relay servers allows us to not always use the same one,
distributing both cost and availability. It also allows to reboot single
relay servers for maintenance without bringing the whole service down. Each
client should pick one or two, this will result in up to four relays being
pinged during relay initialization (remember, there are two clients who both
pick at random). Four connection attempts should be enough to give a
sufficiently high probability of finding one that is up.

The proof of work challenge is added in the attempt to protect the rendezvous
server from a DOS overload. It is a single point of failure, and we want to
be prepared if some dumb-ass spams it with connection attempts for some reason.
The challenge is made in a way that its difficulty is configurable by the server,
thus it can dynamically adapt at the load situation. It is also designed in a
way to be as light on the server resource as possible (also in order to not
accidentally introduce a new DOS vector):

- The server can use the first 8 bytes of the challenge as running counter, only
  that needs to be stored. A binary heap gives
- All other required information are stored and forwarded by the client, a MAC
  protects against clients that make up their challenges.