### PR TITLE
Add changelog for 1.0.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## Unreleased chnages
 
+## Version 1.0.1
+
+- Removed documentation that was specific to the python client
+- A lot of rewording and clarifications of various sub-protocols
+
 ## Version 1.0.0
 
 Initial repository release. This is entirely the same content as in the `docs` folder of the Python implementation.


### PR DESCRIPTION
Not sure if we want to also document changes on the repository itself that are not part of the spec (like build infrastructure and the changed communication channel), but I'm slightly against it.