### PR TITLE
fix semantics of dilation versioning

### DIFF
--- a/dilation-protocol.md
+++ b/dilation-protocol.md
@@ -13,10 +13,13 @@ messages are used to open/use/close the application-visible subchannels.
 
 ## Capability discovery
 
-In the `versions` phase of the protocol, the flag `dilation-v1` may be added to
-the `abilities` list. If both sides include that string in theirs, dilation
-messages may be used. If, in the future, there are multiple dilation versions,
-the highest one supported by both sides must be used.
+The Wormhole protocol includes a `versions` message sent immediately after
+the shared PAKE key is established. This also serves as a key-confirmation
+message, allowing each side to confirm that the other side knows the right
+key. The body of the `versions` message is a JSON-formatted string with keys
+that are available for learning the abilities of the peer. Dilation is
+signaled by a key named `can-dilate`, whose value is a list of strings. Any
+version present in both side's lists is eligible for use.
 
 ## Leaders and Followers
 


### PR DESCRIPTION
The bits about versioning were changed and don't match the magic-wormhole repository nor implementation (and change the semantics subtly). This puts the existing words back.